### PR TITLE
Prevent default option

### DIFF
--- a/snap.svg.zpd.js
+++ b/snap.svg.zpd.js
@@ -364,7 +364,7 @@ SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformTo
 
             var handleMouseOrTouchUp = function handleMouseOrTouchUp (event) {
 
-                if (event.preventDefault && zpdElement.options.preventDefaultEvent) {
+                if (event.preventDefault && zpdElement.options.preventDefaultEvent.handleMouseOrTouchUp) {
                     event.preventDefault();
                 }
 
@@ -386,7 +386,7 @@ SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformTo
 
             var handleMouseOrTouchDown = function handleMouseOrTouchDown (event) {
 
-                if (event.preventDefault && zpdElement.options.preventDefaultEvent) {
+                if (event.preventDefault && zpdElement.options.preventDefaultEvent.handleMouseOrTouchDown) {
                     event.preventDefault();
                 }
 
@@ -425,7 +425,7 @@ SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformTo
 
             var handleMouseMove = function handleMouseMove (event) {
 
-                if (event.preventDefault && zpdElement.options.preventDefaultEvent) {
+                if (event.preventDefault && zpdElement.options.preventDefaultEvent.handleMouseMove) {
                     event.preventDefault();
                 }
 
@@ -481,7 +481,7 @@ SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformTo
                     return;
                 }
 
-                if (event.preventDefault && zpdElement.options.preventDefaultEvent) {
+                if (event.preventDefault && zpdElement.options.preventDefaultEvent.handleMouseWheel) {
                     event.preventDefault();
                 }
 
@@ -507,7 +507,7 @@ SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformTo
                     return;
                 }
 
-                if (event.preventDefault && zpdElement.options.preventDefaultEvent) {
+                if (event.preventDefault && zpdElement.options.preventDefaultEvent.handleTouchMove) {
                     event.preventDefault();
                 }
 
@@ -623,14 +623,20 @@ SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformTo
 
             // define some custom options
             var zpdOptions = {
-                pan: true,                // enable or disable panning (default enabled)
-                panDirections: 'both',    // "both" | "horizontal" | "vertical"
-                zoom: true,               // enable or disable zooming (default enabled)
-                drag: false,              // enable or disable dragging (default disabled)
-                zoomScale: 0.2,           // define zoom sensitivity
-                zoomThreshold: null,      // define zoom threshold
-                touch: true               // enable or disable touch (default enabled)
-                preventDefaultEvent: true // enable or disable preventDefault call in events (default enabled) WARNING may have unwanted effect
+                pan: true,             // enable or disable panning (default enabled)
+                panDirections: 'both', // "both" | "horizontal" | "vertical"
+                zoom: true,            // enable or disable zooming (default enabled)
+                drag: false,           // enable or disable dragging (default disabled)
+                zoomScale: 0.2,        // define zoom sensitivity
+                zoomThreshold: null,   // define zoom threshold
+                touch: true,           // enable or disable touch (default enabled)
+                preventDefaultEvent: { // enable or disable preventDefault call in events (default enabled) WARNING may have unwanted effect
+                    handleMouseOrTouchUp: true,
+                    handleMouseOrTouchDown: true,
+                    handleMouseMove: true,
+                    handleMouseWheel: true,
+                    handleTouchMove: true
+                }
             };
 
             // the situation event of zpd, may be init, reinit, destroy, save, origin, toggle
@@ -661,8 +667,27 @@ SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformTo
 
                 // adapt the stored options, with the options passed in
                 if (typeof options === 'object') {
+                    if (options.preventDefaultEvent !== undefined && typeof options.preventDefaultEvent !== 'object') {
+                        options.preventDefaultEvent = {
+                            handleMouseOrTouchUp: !!options.preventDefaultEvent,
+                            handleMouseOrTouchDown: !!options.preventDefaultEvent,
+                            handleMouseMove: !!options.preventDefaultEvent,
+                            handleMouseWheel: !!options.preventDefaultEvent,
+                            handleTouchMove: !!options.preventDefaultEvent
+                        }
+                    }
+
                     for (var prop in options) {
-                        zpdElement.options[prop] = options[prop];
+                        if (typeof options[prop] === 'object') {
+                            if (typeof zpdElement.options[prop] !== 'object') {
+                                zpdElement.options[prop] = options[prop];
+                            }
+                            for (var subprop in options[prop]) {
+                                zpdElement.options[prop][subprop] = options[prop][subprop];
+                            }
+                        } else {
+                            zpdElement.options[prop] = options[prop];
+                        }
                     }
                     situation = situationState.reinit;
                 } else if (typeof options === 'string') {
@@ -673,8 +698,26 @@ SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformTo
 
                 // adapt the default options
                 if (typeof options === 'object') {
+                    if (options.preventDefaultEvent !== undefined && typeof options.preventDefaultEvent !== 'object') {
+                        options.preventDefaultEvent = {
+                            handleMouseOrTouchUp: !!options.preventDefaultEvent,
+                            handleMouseOrTouchDown: !!options.preventDefaultEvent,
+                            handleMouseMove: !!options.preventDefaultEvent,
+                            handleMouseWheel: !!options.preventDefaultEvent,
+                            handleTouchMove: !!options.preventDefaultEvent
+                        }
+                    }
                     for (var prop2 in options) {
-                        zpdOptions[prop2] = options[prop2];
+                        if (typeof options[prop2] === 'object') {
+                            if (typeof zpdOptions[prop2] !== 'object') {
+                                zpdOptions[prop2] = options[prop2];
+                            }
+                            for (var subprop2 in options[prop2]) {
+                                zpdOptions[prop2][subprop2] = options[prop2][subprop2];
+                            }
+                        } else {
+                            zpdOptions[prop2] = options[prop2];
+                        }
                     }
                     situation = situationState.init;
                 } else if (typeof options === 'string') {

--- a/snap.svg.zpd.js
+++ b/snap.svg.zpd.js
@@ -84,7 +84,7 @@
  */
 
 SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformToElement || function(elem) {
-	return elem.getScreenCTM().inverse().multiply(this.getScreenCTM());
+    return elem.getScreenCTM().inverse().multiply(this.getScreenCTM());
 };
 
 
@@ -175,10 +175,10 @@ SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformTo
                 p.x = event.clientX - svgPos[0];
                 p.y = event.clientY - svgPos[1];
             }
-            
+
             return p;
         };
-        
+
         /**
          * Detect multi-touch (i.e. pinch)
          */
@@ -188,10 +188,10 @@ SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformTo
             if (typeof event.touches != 'undefined' && event.touches.length == 2) {
                 b = true;
             }
-            
+
             return b;
         };
-        
+
         /**
          * Calculate the distance between the 1st and 2nd touches
          */
@@ -229,7 +229,7 @@ SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformTo
                 matrix.a = matrix.a.toFixed(4);
                 matrix.d = matrix.d.toFixed(4);
             }
-            
+
             var threshold = zpdElement.options.zoomThreshold;
 
             if (threshold && typeof threshold === 'object') { // array [0.5,2]
@@ -237,7 +237,7 @@ SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformTo
 
                 if (   (matrix.a < oldMatrix.a && matrix.a < threshold[0])
                     || (matrix.d < oldMatrix.d && matrix.d < threshold[0])) {
-                    
+
                     recalculateMatrix(threshold[0]);
 
                 } else if (   (matrix.a > oldMatrix.a && matrix.a > threshold[1])
@@ -364,7 +364,7 @@ SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformTo
 
             var handleMouseOrTouchUp = function handleMouseOrTouchUp (event) {
 
-                if (event.preventDefault) {
+                if (event.preventDefault && zpdElement.options.preventDefaultEvent) {
                     event.preventDefault();
                 }
 
@@ -386,7 +386,7 @@ SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformTo
 
             var handleMouseOrTouchDown = function handleMouseOrTouchDown (event) {
 
-                if (event.preventDefault) {
+                if (event.preventDefault && zpdElement.options.preventDefaultEvent) {
                     event.preventDefault();
                 }
 
@@ -425,7 +425,7 @@ SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformTo
 
             var handleMouseMove = function handleMouseMove (event) {
 
-                if (event.preventDefault) {
+                if (event.preventDefault && zpdElement.options.preventDefaultEvent) {
                     event.preventDefault();
                 }
 
@@ -439,7 +439,7 @@ SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformTo
 
                     // Pan mode
                     var p = _getEventPoint(event, zpdElement.data.svg).matrixTransform(zpdElement.data.stateTf);
-                    
+
                     var trans_x=0;
                     var trans_y=0;
                     if ((zpdElement.options.panDirections == 'both') || (zpdElement.options.panDirections == 'horizontal')) {
@@ -464,7 +464,7 @@ SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformTo
                     if ((zpdElement.options.panDirections == 'both') || (zpdElement.options.panDirections == 'vertical')) {
                       var trans_y=dragPoint.y - zpdElement.data.stateOrigin.y;
                     }
-                    
+
                     _setCTM(zpdElement.data.stateTarget,
                             zpdElement.data.root.createSVGMatrix()
                             .translate(trans_x, trans_y)
@@ -481,7 +481,7 @@ SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformTo
                     return;
                 }
 
-                if (event.preventDefault) {
+                if (event.preventDefault && zpdElement.options.preventDefaultEvent) {
                     event.preventDefault();
                 }
 
@@ -500,14 +500,14 @@ SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformTo
 
                 _handleZoomingEvent(event, zpdElement, delta);
             };
-            
+
             var handleTouchMove = function handleTouchMove (event) {
 
                 if (!zpdElement.options.zoom || !zpdElement.options.touch) {
                     return;
                 }
 
-                if (event.preventDefault) {
+                if (event.preventDefault && zpdElement.options.preventDefaultEvent) {
                     event.preventDefault();
                 }
 
@@ -526,7 +526,7 @@ SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformTo
 
                         // Case for pinch being closed, make the delta negative
                         if (zpdElement.data.prevZoomDistance > distance) delta = delta * -1;
-                        
+
                         _handleZoomingEvent(event, zpdElement, delta);
                     }
 
@@ -557,7 +557,7 @@ SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformTo
 
             // mobile
             if ('ontouchend' in document.documentElement) {
-            
+
                 svgElement.addEventListener('touchend', handlerFunctions.mouseOrTouchUp, false);
                 svgElement.addEventListener('touchcancel', handlerFunctions.mouseOrTouchUp, false);
                 svgElement.addEventListener('touchstart', handlerFunctions.mouseOrTouchDown, false);
@@ -587,10 +587,10 @@ SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformTo
          * remove event handlers
          */
         var _tearDownHandlers = function tearDownHandlers(svgElement, handlerFunctions) {
-        
+
             // mobile
             if ('ontouchend' in document.documentElement) {
-            
+
                 svgElement.removeEventListener('touchend', handlerFunctions.mouseOrTouchUp, false);
                 svgElement.removeEventListener('touchcancel', handlerFunctions.mouseOrTouchUp, false);
                 svgElement.removeEventListener('touchstart', handlerFunctions.mouseOrTouchDown, false);
@@ -623,13 +623,14 @@ SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformTo
 
             // define some custom options
             var zpdOptions = {
-                pan: true,             // enable or disable panning (default enabled)
-                panDirections: 'both', // "both" | "horizontal" | "vertical"
-                zoom: true,            // enable or disable zooming (default enabled)
-                drag: false,           // enable or disable dragging (default disabled)
-                zoomScale: 0.2,        // define zoom sensitivity
-                zoomThreshold: null,   // define zoom threshold
-                touch: true            // enable or disable touch (default enabled)
+                pan: true,                // enable or disable panning (default enabled)
+                panDirections: 'both',    // "both" | "horizontal" | "vertical"
+                zoom: true,               // enable or disable zooming (default enabled)
+                drag: false,              // enable or disable dragging (default disabled)
+                zoomScale: 0.2,           // define zoom sensitivity
+                zoomThreshold: null,      // define zoom threshold
+                touch: true               // enable or disable touch (default enabled)
+                preventDefaultEvent: true // enable or disable preventDefault call in events (default enabled) WARNING may have unwanted effect
             };
 
             // the situation event of zpd, may be init, reinit, destroy, save, origin, toggle


### PR DESCRIPTION
Hi,
This PR add an option allowing the user to disable the call to event.preventDefault in the plugin event handler.

This is needed because sometimes the user need to add events on the zpd element and the call to preventDefault prevent his events from being triggered.

Some other time it also prevent events from other elements.
For example, if you have the issue #74 use `svg.zpd({preventDefaultEvent:{handleMouseOrTouchDown: false}})` and the onblur event will launch like it should.